### PR TITLE
Update step01-db-setup.mdx

### DIFF
--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
@@ -102,6 +102,12 @@ host all all all md5
 host   replication    streaming_barman   all md5
 ```
 
+### enable remote access to your PostgreSQL Server
+
+set `listen_addresses = '*'` in `postgresql.conf`
+
+otherwise the barman-backup server will not be able to communicate with your PostgreSQL server at all.
+
 ### Database settings for streaming
 
 We'll also need to make sure there are replication slots available, and that PostgreSQL will allow another sender to connect. We'll use psql to check the current settings:

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
@@ -102,19 +102,41 @@ host all all all md5
 host   replication    streaming_barman   all md5
 ```
 
-### enable remote access to your PostgreSQL Server
+### Enable remote access to your PostgreSQL Server
 
-set `listen_addresses = '*'` in `postgresql.conf`
+If the PostgreSQL server isn't already configured for remote access, or is restricted to connections from known machines, our database server won't be able to connect.
 
-otherwise the barman-backup server will not be able to communicate with your PostgreSQL server at all.
-
-### Database settings for streaming
-
-We'll also need to make sure there are replication slots available, and that PostgreSQL will allow another sender to connect. We'll use psql to check the current settings:
+We'll use psql to check this setting:
 
 ```shell
 psql -d pagila
 ```
+
+The relevant configuration parameter is [`listen_addresses`](https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-LISTEN-ADDRESSES):
+
+```shell
+show listen_addresses;
+__OUTPUT__
+ listen_addresses 
+------------------
+ *
+(1 row)
+```
+
+The value for this server is `*` - which allows connections from anything. This doesn't need to be changed. If the value were to be empty, `localhost`, or a list of hosts or addresses that don't include our database server, we'd need to add its hostname (`backup`) to the list, or change it to the wildcard. 
+
+```shell
+pagila=# ALTER SYSTEM SET listen_addresses TO "*";
+__OUTPUT__
+ALTER SYSTEM
+```
+
+!!! Note
+    If you change this setting, you'll need to restart the database server for it to take effect. Since our setting was already allowing all remote connections, we don't need to do that.
+    
+### Database settings for streaming
+
+We'll also need to make sure there are replication slots available, and that PostgreSQL will allow another sender to connect. We'll continue to use psql to check the current settings:
 
 ```sql
 Show max_wal_senders;

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
@@ -114,7 +114,7 @@ psql -d pagila
 
 The relevant configuration parameter is [`listen_addresses`](https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-LISTEN-ADDRESSES):
 
-```shell
+```sql
 show listen_addresses;
 __OUTPUT__
  listen_addresses 
@@ -125,8 +125,8 @@ __OUTPUT__
 
 The value for this server is `*` - which allows connections from anything. This doesn't need to be changed. If the value were to be empty, `localhost`, or a list of hosts or addresses that don't include our database server, we'd need to add its hostname (`backup`) to the list, or change it to the wildcard. 
 
-```shell
-pagila=# ALTER SYSTEM SET listen_addresses TO "*";
+```sql
+ALTER SYSTEM SET listen_addresses TO "*";
 __OUTPUT__
 ALTER SYSTEM
 ```


### PR DESCRIPTION
enabling remote access to your PostgreSQL Server (set `listen_addresses = '*'` in `postgresql.conf`) is missing.

having not set this up will cause complete failure. Troubleshooting may cost an inexperienced PostgreSQL hours.

## What Changed?

Please list, at a high level, what changed in your branch. If you changed content, include the product, section, and version as applicable. **Please remove the user instructions including the examples before merging the PR.**

**Examples**

- Fixed typo in EPAS 13 epas_inst_linux guide
- Added more detail to ARK 3.5 getting started guide introduction
- Fixed broken link on `/supported-open-source/pgbackrest/05-retention_policy/` page

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [x] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
